### PR TITLE
add -x assembler-with-cpp to fix Linux/WSL build

### DIFF
--- a/makefile
+++ b/makefile
@@ -238,4 +238,4 @@ $(STRINGS_OBJS): $(BUILD_DIR)/%.o: %.s
 	$(PREPROC) $< charmap.txt | $(AS) $(ASFLAGS) -o $@ -
 
 $(ASM_SCRIPTS_OBJS): $(BUILD_DIR)/%.o: %.s
-	$(CPP) $(CPPFLAGS) $< | $(AS) $(ASFLAGS) -o $@ -
+	$(CPP) -x assembler-with-cpp $(CPPFLAGS) $< | $(AS) $(ASFLAGS) -o $@ -


### PR DESCRIPTION
Problem: `cc -E` on Linux seems to silently produces no output for lowercase `.s` files, causing all `asm/scripts/*.s` objects to be empty and their symbols to be missing. This appears to not affect macOS because clang preprocesses `.s` files without needing explicit instruction.

Fix: Add `-x assembler-with-cpp` to the `ASM_SCRIPTS_OBJS` recipe so GCC is explicitly told to preprocess the file.

Note that this is not tested on macOS as I do not have access to one.